### PR TITLE
Make requiring pitstop more user-friendly

### DIFF
--- a/src/pitstop/protocols.clj
+++ b/src/pitstop/protocols.clj
@@ -1,0 +1,20 @@
+(ns pitstop.protocols)
+
+(defprotocol Storage
+  (listen [instance]
+    "Start a listener.
+    Return a map of {:data chan :stop chan}
+    Data channel is channel of items: {:ack ack-chan :msg msg} to be sent
+    Upon stop channel closing, listening should cease and channel closed.")
+  (store! [instance msg when]
+          [instance msg start end every]
+    "Store a new _or_ updated deferred or deferred-recurring message
+    Deferred messages with just the when argument will be deferred
+     emitted on the listen channel at time when.
+    Recurring messages will be emitted on a listen channel every interval
+     starting at start and ending at end.
+    Messages may contain {:id id} which should be respected for updates.
+    Returns a ack channel.")
+  (remove! [instance id]
+    "Remove a deferred or recurring message, denoted by a message's id
+    Return a ack channel."))

--- a/src/pitstop/storage/mongo.clj
+++ b/src/pitstop/storage/mongo.clj
@@ -1,5 +1,5 @@
 (ns pitstop.storage.mongo
-  (:require [pitstop.core :as p]
+  (:require [pitstop.protocols :as proto]
             [clojure.string :as string]
             [clojure.core.async :refer (go go-loop chan alt! <! close!) :as async]
             [monger (collection :as mc)
@@ -119,7 +119,7 @@
 ;; Storage implementation
 
 (defrecord MongoStorage [db coll loop-time lock-time]
-  p/Storage
+  proto/Storage
   (listen [inst] (listen inst))
   (store! [inst msg when]
     (update-msg! inst (wrap-deferred-msg msg when)))
@@ -127,8 +127,7 @@
     (update-msg! inst (wrap-recurring-msg msg every start end)))
   (remove! [inst id] (remove-msg! inst id)))
 
-(defmethod p/init! :mongo
-  [{:keys [lock-time loop-time coll] :as cfg}]
+(defn init! [{:keys [lock-time loop-time coll] :as cfg}]
   (mconn/wmong cfg
     (ensure-indices! mconn/db coll)
     (MongoStorage. mconn/db coll


### PR DESCRIPTION
Remove the need for requiring pitstop.storage.mongo in

```
(ns example-ns
    (:require [pitstop.core :as p]
              pitstop.storage.mongo))
```
